### PR TITLE
Testing a start-to-end lpm discovery for trace abc and two place nets

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -6,8 +6,6 @@ name: Java CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
   
 jobs:

--- a/ivy.xml
+++ b/ivy.xml
@@ -37,6 +37,8 @@
 		<dependency conf="lib->default" org="com.google.inject.extensions" name="guice-assistedinject" rev="4.0" />
 		<dependency conf="lib->default" org="com.google.inject.extensions" name="guice-multibindings" rev="4.0" />
 		<dependency conf="lib->default" org="com.github.haifengl" name="smile-core" rev="3.0.2"/>
+		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+		<dependency org="org.assertj" name="assertj-core" rev="3.24.2"/>
 <!--		<dependency org="com.github.beamline" name="simple-pnml" rev="0.0.2"/>-->
     	<!-- dependency conf="lib->default" org="org.reflections" name="reflections" rev="0.9.10" /-->
     	<!-- Third party library downloaded from ProM library. -->

--- a/src/org/processmining/placebasedlpmdiscovery/model/logs/XLogWrapper.java
+++ b/src/org/processmining/placebasedlpmdiscovery/model/logs/XLogWrapper.java
@@ -1,10 +1,16 @@
 package org.processmining.placebasedlpmdiscovery.model.logs;
 
+import org.deckfour.xes.extension.std.XConceptExtension;
+import org.deckfour.xes.factory.XFactory;
+import org.deckfour.xes.factory.XFactoryRegistry;
+import org.deckfour.xes.model.XEvent;
 import org.deckfour.xes.model.XLog;
+import org.deckfour.xes.model.XTrace;
 import org.processmining.placebasedlpmdiscovery.model.logs.activities.Activity;
 import org.processmining.placebasedlpmdiscovery.model.logs.activities.ActivityCache;
 import org.processmining.placebasedlpmdiscovery.utils.LogUtils;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -14,6 +20,22 @@ public class XLogWrapper implements EventLog {
 
     public XLogWrapper(XLog log) {
         this.log = log;
+    }
+
+    public static XLogWrapper fromListOfTracesAsListStrings(List<List<String>> traces) {
+        XFactory factory = XFactoryRegistry.instance().currentDefault();
+        XLog log = factory.createLog();
+
+        for (List<String> trace : traces) {
+            XTrace xTrace = factory.createTrace();
+            for (String event : trace) {
+                XEvent xEvent = factory.createEvent();
+                XConceptExtension.instance().assignName(xEvent, event);
+                xTrace.add(xEvent);
+            }
+            log.add(xTrace);
+        }
+        return new XLogWrapper(log);
     }
 
     @Override

--- a/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
@@ -26,5 +26,13 @@ public interface PlacesProvider {
         return new DiscoveryPlacesProvider(parameters.getAlgorithm(factory));
     }
 
+    static PlacesProvider fromFile(String fileName) {
+        return new FromFilePlacesProvider(fileName);
+    }
+
+    static PlacesProvider fromSet(Set<Place> places) {
+        return log -> places;
+    }
+
     Set<Place> from(XLog log);
 }

--- a/tests-integration/TestPlaceBasedLPMDiscoveryGivenLogAbcWithPlacesAbAc.java
+++ b/tests-integration/TestPlaceBasedLPMDiscoveryGivenLogAbcWithPlacesAbAc.java
@@ -1,0 +1,63 @@
+import org.assertj.core.api.Assertions;
+import org.deckfour.xes.model.XLog;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.processmining.placebasedlpmdiscovery.lpmdiscovery.LPMDiscovery;
+import org.processmining.placebasedlpmdiscovery.lpmdiscovery.PlaceBasedLPMDiscovery;
+import org.processmining.placebasedlpmdiscovery.model.LocalProcessModel;
+import org.processmining.placebasedlpmdiscovery.model.Place;
+import org.processmining.placebasedlpmdiscovery.model.discovery.LPMDiscoveryResult;
+import org.processmining.placebasedlpmdiscovery.model.logs.XLogWrapper;
+import org.processmining.placebasedlpmdiscovery.prom.PlacesProvider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestPlaceBasedLPMDiscoveryGivenLogAbcWithPlacesAbAc {
+
+    private static PlacesProvider placesProvider;
+    private static XLog eventLog;
+
+    @BeforeClass
+    public static void setup() {
+        Set<Place> places = new HashSet<>();
+        places.add(Place.from("a | b"));
+        places.add(Place.from("a | c"));
+        placesProvider = PlacesProvider.fromSet(places);
+
+        XLogWrapper logWrapper = XLogWrapper.fromListOfTracesAsListStrings(Collections.singletonList(
+                Arrays.asList("a", "b", "c")
+        ));
+        eventLog = logWrapper.getOriginalLog();
+    }
+
+    @Test
+    public void givenDefault_whenFrom_thenLPMsAbAc() {
+        // given
+        LPMDiscovery lpmDiscovery = new PlaceBasedLPMDiscovery(placesProvider);
+
+        // when
+        LPMDiscoveryResult result = lpmDiscovery.from(eventLog);
+
+        // then
+        Assert.assertEquals(1, result.getAllLPMs().size());
+        Assertions.assertThat(result.getAllLPMs())
+                .extracting(LocalProcessModel::getShortString)
+                .containsExactlyInAnyOrder("(a | b)(a | c)"); // LPMs need to contain at least two places
+    }
+
+    @Test
+    public void givenDefaultWithPlaceLimit_whenFrom_thenLPMsEmpty() {
+        // given
+        LPMDiscovery lpmDiscovery = new PlaceBasedLPMDiscovery(placesProvider, 1);
+
+        // when
+        LPMDiscoveryResult result = lpmDiscovery.from(eventLog);
+
+        // then
+        Assert.assertTrue(result.getAllLPMs().isEmpty()); // LPMs need to contain at least two places
+    }
+}

--- a/tests/src/org/processmining/placebasedlpmdiscovery/replayer/ReplayerForReplayableLocalProcessModelTest.java
+++ b/tests/src/org/processmining/placebasedlpmdiscovery/replayer/ReplayerForReplayableLocalProcessModelTest.java
@@ -116,7 +116,7 @@ public class ReplayerForReplayableLocalProcessModelTest {
         // act
         Map<String, Set<List<String>>> actualPaths = new HashMap<>();
         for (String lpmKey : modelsWithPaths.keySet()) {
-            actualPaths.put(lpmKey, Replayer.findAllPaths(10, LocalProcessModel.from(lpmKey)));
+            actualPaths.put(lpmKey, ReplayableLocalProcessModelReplayer.findAllPaths(10, LocalProcessModel.from(lpmKey)));
         }
 
         // test


### PR DESCRIPTION
Trace: abc
Place nets: a | b and a | c

To make the test possible:
- We added AssertJ as a dependency to enable more expressive tests
- We extended XLogWrapper with a `from` method that accepts a list of traces, where each trace is a list of activity names.
- We extended PlacesProvider with a method `fromSet` that, when called, returns the given set of place nets.