### PR TITLE
Update PlacesProvider to allow choosing an algorithm and setting discovery parameters

### DIFF
--- a/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
@@ -5,10 +5,7 @@ import org.processmining.placebasedlpmdiscovery.model.Place;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.PlaceDiscoveryAlgorithmId;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithm;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithmFactory;
-import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.EstMinerPlaceDiscoveryParameters;
-import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.HeuristicMinerPlaceDiscoveryParameters;
-import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.InductiveMinerPlaceDiscoveryParameters;
-import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.SPECppPlaceDiscoveryParameters;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.*;
 
 import java.util.Set;
 
@@ -39,6 +36,17 @@ public class FromLogPlacesProvider implements PlacesProvider {
             return inductiveMiner(log);
         }
         throw new IllegalArgumentException("Unsupported PlaceDiscoveryAlgorithmId: " + algorithmId);
+    }
+
+    /**
+     * Creates a PlacesProvider that discovers places using the specified parameters.
+     * @param log the XLog to discover places from
+     * @param placeDiscoveryParameters the parameters to use for place discovery
+     * @return a PlacesProvider that discovers places using the specified parameters
+     */
+    public static PlacesProvider getInstance(XLog log, PlaceDiscoveryParameters placeDiscoveryParameters) {
+        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
+        return new FromLogPlacesProvider(log, placeDiscoveryParameters.getAlgorithm(factory));
     }
 
     @Override

--- a/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
@@ -2,9 +2,12 @@ package org.processmining.placebasedlpmdiscovery.prom;
 
 import org.deckfour.xes.model.XLog;
 import org.processmining.placebasedlpmdiscovery.model.Place;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.PlaceDiscoveryAlgorithmId;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithm;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithmFactory;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.EstMinerPlaceDiscoveryParameters;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.HeuristicMinerPlaceDiscoveryParameters;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.InductiveMinerPlaceDiscoveryParameters;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.SPECppPlaceDiscoveryParameters;
 
 import java.util.Set;
@@ -17,6 +20,25 @@ public class FromLogPlacesProvider implements PlacesProvider {
     public FromLogPlacesProvider(XLog log, PlaceDiscoveryAlgorithm<?, ?> algorithm) {
         this.log = log;
         this.algorithm = algorithm;
+    }
+
+    /**
+     * Creates a PlacesProvider that discovers places using the specified algorithm.
+     * @param log the XLog to discover places from
+     * @param algorithmId the algorithm to use for place discovery
+     * @return a PlacesProvider that discovers places using the specified algorithm
+     */
+    public static PlacesProvider getInstance(XLog log, PlaceDiscoveryAlgorithmId algorithmId) {
+        if (algorithmId == PlaceDiscoveryAlgorithmId.ESTMiner) {
+            return est(log);
+        } else if (algorithmId == PlaceDiscoveryAlgorithmId.SPECpp) {
+            return specpp(log);
+        } else if (algorithmId == PlaceDiscoveryAlgorithmId.HeuristicMiner) {
+            return heuristicMiner(log);
+        } else if (algorithmId == PlaceDiscoveryAlgorithmId.InductiveMiner) {
+            return inductiveMiner(log);
+        }
+        throw new IllegalArgumentException("Unsupported PlaceDiscoveryAlgorithmId: " + algorithmId);
     }
 
     @Override
@@ -55,4 +77,25 @@ public class FromLogPlacesProvider implements PlacesProvider {
         return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
     }
 
+    /**
+     * Creates a PlacesProvider that discovers places using the Heuristic Miner algorithm.
+     * @param log the XLog to discover places from
+     * @return a PlacesProvider that discovers places using the Heuristic Miner algorithm
+     */
+    public static PlacesProvider heuristicMiner(XLog log) {
+        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
+        HeuristicMinerPlaceDiscoveryParameters parameters = new HeuristicMinerPlaceDiscoveryParameters();
+        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+    }
+
+    /**
+     * Creates a PlacesProvider that discovers places using the Inductive Miner algorithm.
+     * @param log the XLog to discover places from
+     * @return a PlacesProvider that discovers places using the Inductive Miner algorithm
+     */
+    public static PlacesProvider inductiveMiner(XLog log) {
+        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
+        InductiveMinerPlaceDiscoveryParameters parameters = new InductiveMinerPlaceDiscoveryParameters();
+        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+    }
 }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
@@ -69,9 +69,8 @@ public class FromLogPlacesProvider implements PlacesProvider {
      * @return a PlacesProvider that discovers places using the EST-Miner algorithm
      */
     public static PlacesProvider est(XLog log) {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
         EstMinerPlaceDiscoveryParameters parameters = new EstMinerPlaceDiscoveryParameters();
-        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+        return getInstance(log, parameters);
     }
 
     /**
@@ -80,9 +79,8 @@ public class FromLogPlacesProvider implements PlacesProvider {
      * @return a PlacesProvider that discovers places using the SPECpp algorithm
      */
     public static PlacesProvider specpp(XLog log) {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
         SPECppPlaceDiscoveryParameters parameters = new SPECppPlaceDiscoveryParameters();
-        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+        return getInstance(log, parameters);
     }
 
     /**
@@ -91,9 +89,8 @@ public class FromLogPlacesProvider implements PlacesProvider {
      * @return a PlacesProvider that discovers places using the Heuristic Miner algorithm
      */
     public static PlacesProvider heuristicMiner(XLog log) {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
         HeuristicMinerPlaceDiscoveryParameters parameters = new HeuristicMinerPlaceDiscoveryParameters();
-        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+        return getInstance(log, parameters);
     }
 
     /**
@@ -102,8 +99,7 @@ public class FromLogPlacesProvider implements PlacesProvider {
      * @return a PlacesProvider that discovers places using the Inductive Miner algorithm
      */
     public static PlacesProvider inductiveMiner(XLog log) {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
         InductiveMinerPlaceDiscoveryParameters parameters = new InductiveMinerPlaceDiscoveryParameters();
-        return new FromLogPlacesProvider(log, parameters.getAlgorithm(factory));
+        return getInstance(log, parameters);
     }
 }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/FromLogPlacesProvider.java
@@ -45,7 +45,7 @@ public class FromLogPlacesProvider implements PlacesProvider {
      * @return a PlacesProvider that discovers places using the specified parameters
      */
     public static PlacesProvider getInstance(XLog log, PlaceDiscoveryParameters placeDiscoveryParameters) {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory();
+        PlaceDiscoveryAlgorithmFactory factory = PlaceDiscoveryAlgorithmFactory.getInstance();
         return new FromLogPlacesProvider(log, placeDiscoveryParameters.getAlgorithm(factory));
     }
 

--- a/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
@@ -2,6 +2,7 @@ package org.processmining.placebasedlpmdiscovery.prom;
 
 import org.deckfour.xes.model.XLog;
 import org.processmining.placebasedlpmdiscovery.model.Place;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.PlaceDiscoveryAlgorithmId;
 
 import java.util.Set;
 
@@ -36,6 +37,16 @@ public interface PlacesProvider {
      */
     static PlacesProvider fromLog(XLog log) {
         return FromLogPlacesProvider.recommended(log);
+    }
+
+    /**
+     * Creates a PlacesProvider that discovers places using the specified algorithm.
+     * @param log the XLog to discover places from
+     * @param algorithmId the algorithm to use for place discovery
+     * @return a PlacesProvider that discovers places using the specified algorithm
+     */
+    static PlacesProvider fromLog(XLog log, PlaceDiscoveryAlgorithmId algorithmId) {
+        return FromLogPlacesProvider.getInstance(log, algorithmId);
     }
 
     /**

--- a/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/PlacesProvider.java
@@ -3,6 +3,7 @@ package org.processmining.placebasedlpmdiscovery.prom;
 import org.deckfour.xes.model.XLog;
 import org.processmining.placebasedlpmdiscovery.model.Place;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.PlaceDiscoveryAlgorithmId;
+import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.PlaceDiscoveryParameters;
 
 import java.util.Set;
 
@@ -42,11 +43,21 @@ public interface PlacesProvider {
     /**
      * Creates a PlacesProvider that discovers places using the specified algorithm.
      * @param log the XLog to discover places from
-     * @param algorithmId the algorithm to use for place discovery
+     * @param placeDiscoveryAlgorithmId the algorithm to use for place discovery
      * @return a PlacesProvider that discovers places using the specified algorithm
      */
-    static PlacesProvider fromLog(XLog log, PlaceDiscoveryAlgorithmId algorithmId) {
-        return FromLogPlacesProvider.getInstance(log, algorithmId);
+    static PlacesProvider fromLog(XLog log, PlaceDiscoveryAlgorithmId placeDiscoveryAlgorithmId) {
+        return FromLogPlacesProvider.getInstance(log, placeDiscoveryAlgorithmId);
+    }
+
+    /**
+     * Creates a PlacesProvider that discovers places using the specified parameters.
+     * @param log the XLog to discover places from
+     * @param placeDiscoveryParameters the parameters to use for place discovery
+     * @return a PlacesProvider that discovers places using the specified parameters
+     */
+    static PlacesProvider fromLog(XLog log, PlaceDiscoveryParameters placeDiscoveryParameters) {
+        return FromLogPlacesProvider.getInstance(log, placeDiscoveryParameters);
     }
 
     /**

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/PlaceDiscoveryAlgorithmId.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/PlaceDiscoveryAlgorithmId.java
@@ -3,5 +3,6 @@ package org.processmining.placebasedlpmdiscovery.prom.placediscovery;
 public enum PlaceDiscoveryAlgorithmId {
     ESTMiner,
     InductiveMiner,
+    SPECpp,
     HeuristicMiner
 }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/StandardPlaceDiscovery.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/StandardPlaceDiscovery.java
@@ -16,7 +16,8 @@ public class StandardPlaceDiscovery implements PlaceDiscovery {
         this.parameters = parameters;
     }
     public PlaceDiscoveryResult getPlaces() {
-        PlaceDiscoveryAlgorithmFactory factory = new PlaceDiscoveryAlgorithmFactory(); // TODO: Why not using the factory directly?
+        // TODO: Why not using the factory directly?
+        PlaceDiscoveryAlgorithmFactory factory = PlaceDiscoveryAlgorithmFactory.getInstance();
         PlaceDiscoveryAlgorithm<? extends PlaceDiscoveryParameters, ?> algorithm = parameters.getAlgorithm(factory);
         return algorithm.getPlaces(log);
     }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/algorithms/PlaceDiscoveryAlgorithmFactory.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/algorithms/PlaceDiscoveryAlgorithmFactory.java
@@ -8,6 +8,10 @@ import org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters.S
 
 public class PlaceDiscoveryAlgorithmFactory {
 
+    public static PlaceDiscoveryAlgorithmFactory getInstance() {
+        return new PlaceDiscoveryAlgorithmFactory();
+    }
+
     public EstMinerPlaceDiscoveryAlgorithm createPlaceDiscoveryAlgorithm(EstMinerPlaceDiscoveryParameters parameters) {
         return new EstMinerPlaceDiscoveryAlgorithm(new PetriNetPlaceConverter(), parameters);
     }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/EstMinerPlaceDiscoveryParameters.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/EstMinerPlaceDiscoveryParameters.java
@@ -7,7 +7,7 @@ import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.P
 import org.processmining.v7.postproc_after_tc.MyParameters;
 //import org.processmining.v8.eSTMinerGIT.Parameters;
 
-public class EstMinerPlaceDiscoveryParameters extends PlaceDiscoveryParameters {
+public class EstMinerPlaceDiscoveryParameters implements PlaceDiscoveryParameters {
     private MyParameters wrappedParameters;
 
     public EstMinerPlaceDiscoveryParameters() {

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/HeuristicMinerPlaceDiscoveryParameters.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/HeuristicMinerPlaceDiscoveryParameters.java
@@ -5,7 +5,7 @@ import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.P
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithmFactory;
 import org.processmining.plugins.heuristicsnet.miner.heuristics.miner.settings.HeuristicsMinerSettings;
 
-public class HeuristicMinerPlaceDiscoveryParameters extends PlaceDiscoveryParameters {
+public class HeuristicMinerPlaceDiscoveryParameters implements PlaceDiscoveryParameters {
 
     private HeuristicsMinerSettings settings;
 

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/InductiveMinerPlaceDiscoveryParameters.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/InductiveMinerPlaceDiscoveryParameters.java
@@ -7,7 +7,7 @@ import org.processmining.plugins.InductiveMiner.mining.MiningParameters;
 import org.processmining.plugins.InductiveMiner.mining.MiningParametersIM;
 import org.processmining.plugins.InductiveMiner.plugins.dialogs.IMMiningDialog;
 
-public class InductiveMinerPlaceDiscoveryParameters extends PlaceDiscoveryParameters {
+public class InductiveMinerPlaceDiscoveryParameters implements PlaceDiscoveryParameters {
     private MiningParameters miningParameters;
     private IMMiningDialog.Variant variant;
 

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/PlaceDiscoveryParameters.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/PlaceDiscoveryParameters.java
@@ -3,7 +3,7 @@ package org.processmining.placebasedlpmdiscovery.prom.placediscovery.parameters;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithm;
 import org.processmining.placebasedlpmdiscovery.prom.placediscovery.algorithms.PlaceDiscoveryAlgorithmFactory;
 
-public abstract class PlaceDiscoveryParameters {
+public interface PlaceDiscoveryParameters {
 
-    public abstract PlaceDiscoveryAlgorithm<? extends PlaceDiscoveryParameters, ?> getAlgorithm(PlaceDiscoveryAlgorithmFactory factory);
+    PlaceDiscoveryAlgorithm<? extends PlaceDiscoveryParameters, ?> getAlgorithm(PlaceDiscoveryAlgorithmFactory factory);
 }

--- a/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/SPECppPlaceDiscoveryParameters.java
+++ b/src/org/processmining/placebasedlpmdiscovery/prom/placediscovery/parameters/SPECppPlaceDiscoveryParameters.java
@@ -11,7 +11,7 @@ import org.processmining.specpp.config.presets.BaseParameters;
 import org.processmining.specpp.config.presets.PlaceOracleComponentConfig;
 import org.processmining.specpp.config.presets.PlaceOracleParameters;
 
-public class SPECppPlaceDiscoveryParameters extends PlaceDiscoveryParameters {
+public class SPECppPlaceDiscoveryParameters implements PlaceDiscoveryParameters {
     private final SPECppConfigBundle configBundle;
 
     public SPECppPlaceDiscoveryParameters() {


### PR DESCRIPTION
- `PlacesProvider.fromLog` now has two additional variants: (1) algorithmId parameter (default discovery parameters) or (2) discovery parameters
- Change PlaceDiscoveryParameters to be an interface instead of an abstract class
- Replace repetitive code with a unified call for the different place discovery variants